### PR TITLE
Add Augmented Operators

### DIFF
--- a/docs/grammar_rules.md
+++ b/docs/grammar_rules.md
@@ -28,13 +28,15 @@ Below is the complete grammar definition:
 ```grammar
 multiline: NEWLINE* (singleline)* (NEWLINE* (singleline))* NEWLINE*
 
-singleline: function-call | statements | if-expression | for-expression | while-expression | switch-statement | function-definition
+singleline: function-call | statements | if-expression | for-expression | while-expression | switch-statement | function-definition | augmented-statement
 
 yield-statement: KEYWORD:yield expression
 
 jump-statements: KEYWORD:proceed | KEYWORD:escape
 
 statements: IDENTIFIER (LPAREN3 expression RPAREN3)* (COMMA IDENTIFIER (LPAREN3 expression RPAREN3)*)* EQUAL expression (COMMA expression)*
+
+augmented-statement: IDENTIFIER (LPAREN3 expression RPAREN3)* (COMMA IDENTIFIER (LPAREN3 expression RPAREN3)*)* (PLUSEQUAL | MINUSEQUAL | MULEQUAL | DIVEQUAL | MODEQUAL | FLOOREQUAL) expression (COMMA expression)*
 
 switch-statement: KEYWORD:menu ternary-expression LPAREN2 NEWLINE* (case-statement* NEWLINE*)* default-statement? NEWLINE* (case-statement* NEWLINE*)* RPAREN2
 
@@ -52,7 +54,7 @@ comp-expression: KEYWORD:NOT comp-expression | arith-expression ((EE | NEQ | LT 
 
 arith-expression: term ((PLUS | MINUS) term)*
 
-term: unary ((MUL | DIV | MODULUS | FLOOR_DIV) unary)*
+term: unary ((MUL | DIV | MOD | FLOOR) unary)*
 
 unary: (PLUS | MINUS) unary | exponent
 

--- a/docs/grammar_rules.md
+++ b/docs/grammar_rules.md
@@ -34,9 +34,7 @@ yield-statement: KEYWORD:yield expression
 
 jump-statements: KEYWORD:proceed | KEYWORD:escape
 
-statements: IDENTIFIER (LPAREN3 expression RPAREN3)* (COMMA IDENTIFIER (LPAREN3 expression RPAREN3)*)* EQUAL expression (COMMA expression)*
-
-augmented-statement: IDENTIFIER (LPAREN3 expression RPAREN3)* (COMMA IDENTIFIER (LPAREN3 expression RPAREN3)*)* (PLUSEQUAL | MINUSEQUAL | MULEQUAL | DIVEQUAL | MODEQUAL | FLOOREQUAL) expression (COMMA expression)*
+statements: IDENTIFIER (LPAREN3 expression RPAREN3)* (COMMA IDENTIFIER (LPAREN3 expression RPAREN3)*)* (EQUAL | PLUSEQUAL | MINUSEQUAL | MULEQUAL | DIVEQUAL | MODEQUAL | FLOOREQUAL) expression (COMMA expression)*
 
 switch-statement: KEYWORD:menu ternary-expression LPAREN2 NEWLINE* (case-statement* NEWLINE*)* default-statement? NEWLINE* (case-statement* NEWLINE*)* RPAREN2
 

--- a/docs/grammar_rules.md
+++ b/docs/grammar_rules.md
@@ -28,7 +28,7 @@ Below is the complete grammar definition:
 ```grammar
 multiline: NEWLINE* (singleline)* (NEWLINE* (singleline))* NEWLINE*
 
-singleline: function-call | statements | if-expression | for-expression | while-expression | switch-statement | function-definition | augmented-statement
+singleline: function-call | statements | if-expression | for-expression | while-expression | switch-statement | function-definition
 
 yield-statement: KEYWORD:yield expression
 

--- a/sards/core/constants.py
+++ b/sards/core/constants.py
@@ -18,12 +18,19 @@ T_STRING = 'STRING'
 T_IDENTIFIER = 'IDENTIFIER'  # Identifier token
 T_KEYWORD = 'KEYWORD'
 T_PLUS = 'PLUS'  # Addition operator (+)
+T_PLUSEQUAL = 'PLUSEQUAL' # Augmented addition operator (+=)
 T_MINUS = 'MINUS'  # Subtraction operator (-)
+T_MINUSEQUAL = 'MINUSEQUAL' # Augmented subtraction operator (-=)
 T_MUL = 'MUL'  # Multiplication operator (*)
+T_MULEQUAL = 'MULEQUAL' # Augmented multiplication operator (*=)
 T_DIVIDE = 'DIV'  # Division operator (/)
-T_MODULUS = 'MOD'
-T_FLOOR = 'FLOOR'
+T_DIVIDEEQUAL = 'DIVEQUAL' # Augmented division operator (/=)
+T_MODULUS = 'MOD' # Modulus operator (%)
+T_MODULUSEQUAL = 'MODEQUAL' # Augmented modulus operator (%=)
+T_FLOOR = 'FLOOR' # Floor division operator (//)
+T_FLOOREQUAL = 'FLOOREQUAL' # Augmented floor division operator (//=)
 T_EXP = 'EXP'  # Exponentiation operator (**)
+T_EXPEQUAL = 'EXPEQUAL' 
 T_EQ = 'EQUAL'
 T_NEQ = 'NOTEQUAL'
 T_EE = 'DOUBLEEQUAL'

--- a/sards/core/lexer.py
+++ b/sards/core/lexer.py
@@ -108,6 +108,12 @@ class Lexer:
         if self.current_char == '/':
             self.advance()
             token_type = T_FLOOR
+            if self.current_char == '=':
+                self.advance()
+                token_type = T_FLOOREQUAL
+        elif self.current_char == '=':
+            self.advance()
+            token_type = T_DIVIDEEQUAL
 
         return Token(token_type, pos_start=pos_start, pos_end=self.pos)
 
@@ -119,6 +125,23 @@ class Lexer:
         if self.current_char == '*':
             self.advance()
             token_type = T_EXP
+            if self.current_char == '=':
+                self.advance()
+                token_type = T_EXPEQUAL
+        elif self.current_char == '=':
+            self.advance()
+            token_type = T_MULEQUAL
+
+        return Token(token_type, pos_start=pos_start, pos_end=self.pos)
+
+    def make_plus(self):
+        pos_start = self.pos.copy()
+        self.advance()
+        token_type = T_PLUS
+
+        if self.current_char == "=":
+            self.advance()
+            token_type = T_PLUSEQUAL
 
         return Token(token_type, pos_start=pos_start, pos_end=self.pos)
 
@@ -130,8 +153,22 @@ class Lexer:
         if self.current_char==">":
             self.advance()
             token_type=T_ARROW
+        elif self.current_char=="=":
+            self.advance()
+            token_type=T_MINUSEQUAL
 
         return Token(token_type,pos_start=pos_start,pos_end=self.pos)
+    
+    def make_mod(self):
+        pos_start = self.pos.copy()
+        self.advance()
+        token_type = T_MODULUS
+
+        if self.current_char == '=':
+            self.advance()
+            token_type = T_MODULUSEQUAL
+
+        return Token(token_type, pos_start=pos_start, pos_end=self.pos)
 
     def make_not_equals(self):
         pos_start = self.pos.copy()
@@ -235,8 +272,7 @@ class Lexer:
             elif self.current_char == '"':
                 tokens.append(self.make_string())
             elif self.current_char == '+':
-                self.advance()
-                tokens.append(Token(T_PLUS, pos_start=self.pos))
+                tokens.append(self.make_plus())
             elif self.current_char == '-':
                 tokens.append(self.make_sub())
             elif self.current_char == '*':
@@ -244,8 +280,7 @@ class Lexer:
             elif self.current_char == '/':
                 tokens.append(self.make_floor())
             elif self.current_char == '%':
-                tokens.append(Token(T_MODULUS, pos_start=self.pos))
-                self.advance()
+                tokens.append(self.make_mod())
             elif self.current_char == '=':
                 tokens.append(self.make_equals())
             elif self.current_char == '!':
@@ -292,3 +327,4 @@ class Lexer:
 
         tokens.append(Token(T_EOF, pos_start=self.pos))
         return tokens, None
+

--- a/sards/core/parser.py
+++ b/sards/core/parser.py
@@ -1370,7 +1370,7 @@ class Parser: # pylint: disable=R0904
 
         # --- Validation: number of vars == number of values
         if len(var_name_toks) != len(value_nodes):
-            if operator and len(var_name_toks) > 1 and len(value_nodes) == 1:
+            if operator and len(value_nodes) == 1:
                 # Allow cases like: a, b += 5
                 for i in range(1, len(var_name_toks)):
                     value_nodes.append(BinaryOperationNode(

--- a/sards/core/parser.py
+++ b/sards/core/parser.py
@@ -1278,7 +1278,8 @@ class Parser: # pylint: disable=R0904
         statements:
             IDENTIFIER (LPAREN3 expression RPAREN3)*
             (COMMA IDENTIFIER (LPAREN3 expression RPAREN3)*)*
-            EQUAL expression (COMMA expression)*
+            (PLUSEQUAL | MINUSEQUAL | MULEQUAL | DIVEQUAL | MODEQUAL | FLOOREQUAL | EXPEQUAL)
+            expression (COMMA expression)*
         """
         res = ParseResult()
 
@@ -1329,15 +1330,25 @@ class Parser: # pylint: disable=R0904
             res.register_advancement()
             self.advance()
 
+        operator = None
+
         # --- Expect '='
         if self.current_tok.type != T_EQ:
-            return res.failure(
-                InvalidSyntaxError(
-                    self.current_tok.pos_start,
-                    self.current_tok.pos_end,
-                    "Expected '='"
+            # --- Expect augmented operator
+            if self.current_tok.type in (T_PLUSEQUAL, T_MINUSEQUAL, T_MULEQUAL, T_DIVIDEEQUAL, T_MODULUSEQUAL, T_FLOOREQUAL, T_EXPEQUAL):
+                operator = Token(
+                    self.current_tok.type.replace('EQUAL', ''),
+                    pos_start=self.current_tok.pos_start,
+                    pos_end=self.current_tok.pos_end
                 )
-            )
+            else:
+                return res.failure(
+                    InvalidSyntaxError(
+                        self.current_tok.pos_start,
+                        self.current_tok.pos_end,
+                        "Expected '=' or '+=' or '-=' or '*=' or '/=' or '%=' or '//=' or '**='"
+                    )
+                )
         res.register_advancement()
         self.advance()
 
@@ -1346,7 +1357,11 @@ class Parser: # pylint: disable=R0904
             expr = res.register(self.expression())
             if res.error:
                 return res
-            value_nodes.append(expr)
+            if not operator:
+                value_nodes.append(expr)
+            else:
+                val1 = expr
+                value_nodes.append(BinaryOperationNode(left_node=VariableUseNode(var_name_tok=var_name_toks[len(value_nodes)], index_node=index_nodes[len(value_nodes)]), operator=operator, right_node=expr))
 
             if self.current_tok.type != T_COMMA:
                 break
@@ -1355,115 +1370,24 @@ class Parser: # pylint: disable=R0904
 
         # --- Validation: number of vars == number of values
         if len(var_name_toks) != len(value_nodes):
-            return res.failure(
-                InvalidSyntaxError(
-                    var_name_toks[0].pos_start,
-                    value_nodes[-1].pos_end,
-                    f"Mismatched assignment count: {len(var_name_toks)} variables, {len(value_nodes)} values"
-                )
-            )
-
-        return res.success(VariableAssignNode(var_name_toks, value_nodes, index_nodes))
-
-    def augmented_statements(self):
-        """
-        augmented-statements:
-            IDENTIFIER (LPAREN3 expression RPAREN3)*
-            (COMMA IDENTIFIER (LPAREN3 expression RPAREN3)*)*
-            (PLUSEQUAL | MINUSEQUAL | MULEQUAL | DIVEQUAL | MODEQUAL | FLOOREQUAL | EXPEQUAL) expression (COMMA expression)*
-        """
-        res = ParseResult()
-
-        var_name_toks = []
-        index_nodes = []
-        value_nodes = []
-
-        # --- Parse LHS (variables and optional indices)
-        while True:
-            if self.current_tok.type != T_IDENTIFIER:
+            if operator and len(var_name_toks) > 1 and len(value_nodes) == 1:
+                # Allow cases like: a, b += 5
+                for i in range(1, len(var_name_toks)):
+                    value_nodes.append(BinaryOperationNode(
+                        left_node=VariableUseNode(var_name_tok=var_name_toks[i], index_node=index_nodes[i]),
+                        operator=operator,
+                        right_node=val1
+                    ))
+            else:
                 return res.failure(
                     InvalidSyntaxError(
-                        self.current_tok.pos_start,
-                        self.current_tok.pos_end,
-                        "Expected identifier"
+                        var_name_toks[0].pos_start,
+                        value_nodes[-1].pos_end,
+                        f"Mismatched assignment count: {len(var_name_toks)} variables, {len(value_nodes)} values"
                     )
-                )
-
-            var_name_toks.append(self.current_tok)
-            res.register_advancement()
-            self.advance()
-
-            indices = []
-            while self.current_tok and self.current_tok.type == T_LPAREN3:
-                res.register_advancement()
-                self.advance()
-
-                expr = res.register(self.expression())
-                if res.error:
-                    return res
-                indices.append(expr)
-
-                if self.current_tok.type != T_RPAREN3:
-                    return res.failure(
-                        InvalidSyntaxError(
-                            self.current_tok.pos_start,
-                            self.current_tok.pos_end,
-                            "Expected ')'"
-                        )
-                    )
-                res.register_advancement()
-                self.advance()
-
-            index_nodes.append(indices if indices else None)
-
-            if self.current_tok.type != T_COMMA:
-                break
-            res.register_advancement()
-            self.advance()
-
-        # --- Expect augmented assignment operator
-        if self.current_tok.type not in (T_PLUSEQUAL, T_MINUSEQUAL, T_MULEQUAL, T_DIVIDEEQUAL, T_MODULUSEQUAL, T_FLOOREQUAL, T_EXPEQUAL):
-            return res.failure(
-                InvalidSyntaxError(
-                    self.current_tok.pos_start,
-                    self.current_tok.pos_end,
-                    "Expected '+=' or '-=' or '*=' or '/=' or '%=' or '//=' or '**='"
-                )
-            )
-        operator = Token(
-            self.current_tok.type.replace('EQUAL', ''),  # Remove 'EQUAL' from token type
-            pos_start=self.current_tok.pos_start,
-            pos_end=self.current_tok.pos_end
-        )
-        res.register_advancement()
-        self.advance()
-
-        # --- Parse RHS (expressions)
-        idx = 0
-        while True:
-            expr = res.register(self.expression())
-            if res.error:
-                return res
-            if var_name_toks[idx]:
-                value_nodes.append(BinaryOperationNode(left_node=VariableUseNode(var_name_tok=var_name_toks[idx], index_node=index_nodes[idx]), operator=operator, right_node=expr))
-            idx+=1
-
-            if self.current_tok.type != T_COMMA:
-                break
-            res.register_advancement()
-            self.advance()
-
-        if len(var_name_toks) != len(value_nodes):
-            return res.failure(
-                InvalidSyntaxError(
-                    var_name_toks[0].pos_start,
-                    value_nodes[-1].pos_end,
-                    f"Mismatched assignment count: {len(var_name_toks)} variables, {len(value_nodes)} values"
-                )
             )
 
         return res.success(VariableAssignNode(var_name_toks, value_nodes, index_nodes))
-
 
     def jump_statements(self):
         res = ParseResult()

--- a/sards/core/parser.py
+++ b/sards/core/parser.py
@@ -30,6 +30,7 @@ from sards.ast_nodes import *
 from sards.data_types import ListNode, StringNode
 from .constants import *
 from .error import InvalidSyntaxError
+from .lexer import Token
 
 class ParseResult:
     """Stores the result of a parsing operation, including errors and the parsed node."""
@@ -1363,6 +1364,106 @@ class Parser: # pylint: disable=R0904
             )
 
         return res.success(VariableAssignNode(var_name_toks, value_nodes, index_nodes))
+
+    def augmented_statements(self):
+        """
+        augmented-statements:
+            IDENTIFIER (LPAREN3 expression RPAREN3)*
+            (COMMA IDENTIFIER (LPAREN3 expression RPAREN3)*)*
+            (PLUSEQUAL | MINUSEQUAL | MULEQUAL | DIVEQUAL | MODEQUAL | FLOOREQUAL | EXPEQUAL) expression (COMMA expression)*
+        """
+        res = ParseResult()
+
+        var_name_toks = []
+        index_nodes = []
+        value_nodes = []
+
+        # --- Parse LHS (variables and optional indices)
+        while True:
+            if self.current_tok.type != T_IDENTIFIER:
+                return res.failure(
+                    InvalidSyntaxError(
+                        self.current_tok.pos_start,
+                        self.current_tok.pos_end,
+                        "Expected identifier"
+                    )
+                )
+
+            var_name_toks.append(self.current_tok)
+            res.register_advancement()
+            self.advance()
+
+            indices = []
+            while self.current_tok and self.current_tok.type == T_LPAREN3:
+                res.register_advancement()
+                self.advance()
+
+                expr = res.register(self.expression())
+                if res.error:
+                    return res
+                indices.append(expr)
+
+                if self.current_tok.type != T_RPAREN3:
+                    return res.failure(
+                        InvalidSyntaxError(
+                            self.current_tok.pos_start,
+                            self.current_tok.pos_end,
+                            "Expected ')'"
+                        )
+                    )
+                res.register_advancement()
+                self.advance()
+
+            index_nodes.append(indices if indices else None)
+
+            if self.current_tok.type != T_COMMA:
+                break
+            res.register_advancement()
+            self.advance()
+
+        # --- Expect augmented assignment operator
+        if self.current_tok.type not in (T_PLUSEQUAL, T_MINUSEQUAL, T_MULEQUAL, T_DIVIDEEQUAL, T_MODULUSEQUAL, T_FLOOREQUAL, T_EXPEQUAL):
+            return res.failure(
+                InvalidSyntaxError(
+                    self.current_tok.pos_start,
+                    self.current_tok.pos_end,
+                    "Expected '+=' or '-=' or '*=' or '/=' or '%=' or '//=' or '**='"
+                )
+            )
+        operator = Token(
+            self.current_tok.type.replace('EQUAL', ''),  # Remove 'EQUAL' from token type
+            pos_start=self.current_tok.pos_start,
+            pos_end=self.current_tok.pos_end
+        )
+        res.register_advancement()
+        self.advance()
+
+        # --- Parse RHS (expressions)
+        idx = 0
+        while True:
+            expr = res.register(self.expression())
+            if res.error:
+                return res
+            if var_name_toks[idx]:
+                value_nodes.append(BinaryOperationNode(left_node=VariableUseNode(var_name_tok=var_name_toks[idx], index_node=index_nodes[idx]), operator=operator, right_node=expr))
+            idx+=1
+
+            if self.current_tok.type != T_COMMA:
+                break
+            res.register_advancement()
+            self.advance()
+
+        if len(var_name_toks) != len(value_nodes):
+            return res.failure(
+                InvalidSyntaxError(
+                    var_name_toks[0].pos_start,
+                    value_nodes[-1].pos_end,
+                    f"Mismatched assignment count: {len(var_name_toks)} variables, {len(value_nodes)} values"
+                )
+            )
+
+        return res.success(VariableAssignNode(var_name_toks, value_nodes, index_nodes))
+
 
     def jump_statements(self):
         res = ParseResult()


### PR DESCRIPTION
## Augmented Operator support
This PR adds support for augmented assignment operators (`+=`, `-=`, `*=`, `/=` and `%=`) to the language.

### Allowed Formats:
`a += b` &rarr; `a = a + b`
`a1, a2, a3... an += b` &rarr; `a1 = a1 + b, a2 = a2 + b... an = an + b`
`a1, a2, a3... an += b1, b2, b3... bn` &rarr; `a1 = a1 + b1, a2 = a2 + b2... an = an + bn`
