### PR TITLE
Add default function parameters

### DIFF
--- a/docs/grammar_rules.md
+++ b/docs/grammar_rules.md
@@ -40,9 +40,9 @@ attr-list: attr-item (COMMA attr-item)*
 
 attr-item: IDENTIFIER (EQUAL expression)?
 
-constructor-definition: KEYWORD:init LPAREN (IDENTIFIER (COMMA IDENTIFIER)*)? RPAREN LPAREN2 NEWLINE* (initializer-list)? (multiline | jump-statements)* NEWLINE* RPAREN2
+method-definition: (KEYWORD:open | KEYWORD:guarded | KEYWORD:secret)? KEYWORD:method IDENTIFIER? LPAREN (param-list)? RPAREN LPAREN2 (multiline |jump-statements)* RPAREN2
 
-method-definition: (KEYWORD:open | KEYWORD:guarded | KEYWORD:secret)? KEYWORD:method IDENTIFIER? LPAREN (IDENTIFIER (COMMA IDENTIFIER)*)? RPAREN LPAREN2 (multiline |jump-statements)* RPAREN2
+constructor-definition: KEYWORD:init LPAREN (param-list)? RPAREN LPAREN2 NEWLINE* (initializer-list)? (multiline | jump-statements)* NEWLINE* RPAREN2
 
 initializer-list: initializer-item ((COMMA NEWLINE* | NEWLINE+) initializer-item)*
 
@@ -57,6 +57,10 @@ switch-statement: KEYWORD:menu ternary-expression LPAREN2 NEWLINE* (case-stateme
 case-statement: KEYWORD:choice ternary-expression LPAREN2 ((expression | statements) RPAREN2) | (NEWLINE multiline RPAREN2)
 
 default-statement: KEYWORD:fallback LPAREN2 ((expression | statements) RPAREN2) | (NEWLINE multiline RPAREN2)
+
+param-list: param-item (COMMA param-item)*
+
+param-item: IDENTIFIER (EQUAL expression)?
 
 expression: ternary-expression
 
@@ -74,7 +78,15 @@ unary: (PLUS | MINUS) unary | exponent
 
 exponent: call (EXP unary)*
 
-call:attr-access (LPAREN (expression(COMMA expression)*)? RPAREN)*
+argument-list: positional-list (COMMA keyword-list)? | keyword-list
+
+positional-list: expression (COMMA expression)*
+
+keyword-list: keyword-item (COMMA keyword-item)*
+
+keyword-item: IDENTIFIER EQUAL expression
+
+call: attr-access (LPAREN (argument-list)? RPAREN)*
 
 attr-access: factor (DOT IDENTIFIER)*
 
@@ -96,7 +108,7 @@ while-expression: KEYWORD:whenever expression LPAREN2 (multiline | jump-statemen
 
 for-expression: KEYWORD:Cycle IDENTIFIER EQUAL expression COLON expression (COLON expression)? LPAREN2 (multiline | jump-statements)* RPAREN2
 
-function-definition: KEYWORD:method IDENTIFIER? LPAREN (IDENTIFIER (COMMA IDENTIFIER)*)? RPAREN LPAREN2 (multiline |jump-statements)* RPAREN2
+function-definition: KEYWORD:method IDENTIFIER? LPAREN (param-list)? RPAREN LPAREN2 (multiline |jump-statements)* RPAREN2
 
 if-expression: KEYWORD:when expression LPAREN2 (multiline | jump-statements)* RPAREN2 NEWLINE* (elif-expression | else-expression)?
 

--- a/sards/ast_nodes/class_node.py
+++ b/sards/ast_nodes/class_node.py
@@ -37,22 +37,30 @@ class AttrNode:
 class InitNode:  # pylint: disable=R0903
     """
     Represents an 'init' (constructor) definition in the AST.
+    Now supports default parameter values.
 
     Attributes:
-        param_name_toks: A list of tokens for the parameter names.
+        param_nodes: A list of tuples: [(name_tok, default_value_node), ...]
+                     default_value_node is None if no default.
         body_node: The node representing the body of the constructor.
         pos_start: The starting position of the 'init' keyword.
         pos_end: The ending position of the constructor body.
     """
-    def __init__(self, param_name_toks, body_node, pos_start, pos_end):
-        self.param_name_toks = param_name_toks
+    def __init__(self, param_nodes, body_node, pos_start, pos_end):
+        self.param_nodes = param_nodes
         self.body_node = body_node
         self.pos_start = pos_start
         self.pos_end = pos_end
 
     def __repr__(self):
-        params = [p.value for p in self.param_name_toks]
-        return f"(Init: ({params}), Body: {self.body_node})"
+        # Updated __repr__ to show parameters and their defaults
+        param_reprs = []
+        for name_tok, default_value in self.param_nodes:
+            if default_value:
+                param_reprs.append(f"({name_tok.value}={default_value})")
+            else:
+                param_reprs.append(name_tok.value)
+        return f"(Init: ({', '.join(param_reprs)}), Body: {self.body_node})"
 
 
 class AttrAccessNode:  # pylint: disable=R0903

--- a/sards/ast_nodes/functions_node.py
+++ b/sards/ast_nodes/functions_node.py
@@ -1,20 +1,11 @@
-"""
-This module defines the FunctionDefinitionNode and FunctionCallNode classes,
-which represent function definition and function call nodes in the abstract syntax tree (AST).
-
-Classes:
-    FunctionDefinitionNode: A class to represent a function definition node in the AST.
-    FunctionCallNode: A class to represent a function call node in the AST.
-"""
-
 class FunctionDefinitionNode:
     """
     Represents a function OR method definition in the AST.
+    Now supports default parameter values.
     """
-
-    def __init__(self, var_name_tok, arg_name_toks, body_node, auto_return, access_modifier_tok=None):
+    def __init__(self, var_name_tok, arg_nodes, body_node, auto_return, access_modifier_tok=None):
         self.var_name_tok = var_name_tok
-        self.arg_name_toks = arg_name_toks
+        self.arg_nodes = arg_nodes
         self.body_node = body_node
         self.auto_return = auto_return
         self.access_modifier_tok = access_modifier_tok
@@ -23,37 +14,46 @@ class FunctionDefinitionNode:
             self.pos_start = self.access_modifier_tok.pos_start
         elif self.var_name_tok:
             self.pos_start = self.var_name_tok.pos_start
-        elif len(self.arg_name_toks) > 0:
-            self.pos_start = self.arg_name_toks[0].pos_start
+        elif len(self.arg_nodes) > 0:
+            self.pos_start = self.arg_nodes[0][0].pos_start
         else:
             self.pos_start = self.body_node.pos_start
 
         self.pos_end = self.body_node.pos_end
 
     def __repr__(self):
+        arg_reprs = []
+        for arg_name, default_value in self.arg_nodes:
+            if default_value:
+                arg_reprs.append(f"({arg_name}={default_value})")
+            else:
+                arg_reprs.append(f"{arg_name}")
+        
         return (f'{self.access_modifier_tok}:{self.var_name_tok}:'
-                f'{self.arg_name_toks}:{self.body_node}')
+                f'ARGS=[{", ".join(arg_reprs)}]:{self.body_node}')
 
-class FunctionCallNode: # pylint: disable=R0903
+
+class FunctionCallNode:  # pylint: disable=R0903
     """
     Represents a function call node in the abstract syntax tree (AST).
-
-    Attributes:
-        call_node: The node representing the function being called.
-        arg_nodes: A list of nodes representing the arguments passed to the function.
-        pos_start: The starting position of the function call in the source code.
-        pos_end: The ending position of the function call in the source code.
+    Now supports both positional and keyword arguments.
     """
-    def __init__(self, call_node, arg_nodes):
+    def __init__(self, call_node, positional_arg_nodes, keyword_arg_nodes):
         self.call_node = call_node
-        self.arg_nodes = arg_nodes
+        self.positional_arg_nodes = positional_arg_nodes
+
+        self.keyword_arg_nodes = keyword_arg_nodes
 
         self.pos_start = self.call_node.pos_start
 
-        if len(self.arg_nodes) > 0:
-            self.pos_end = self.arg_nodes[-1].pos_end
+        if len(self.keyword_arg_nodes) > 0:
+            self.pos_end = self.keyword_arg_nodes[-1][1].pos_end
+        elif len(self.positional_arg_nodes) > 0:
+            self.pos_end = self.positional_arg_nodes[-1].pos_end
         else:
             self.pos_end = self.call_node.pos_end
 
     def __repr__(self):
-        return f'{self.call_node}:{self.arg_nodes}'
+        keyword_reprs = [f"({name}={value})" for name, value in self.keyword_arg_nodes]
+        all_args = self.positional_arg_nodes + keyword_reprs
+        return f'{self.call_node}:ARGS=({", ".join(map(str, all_args))})'

--- a/sards/core/__init__.py
+++ b/sards/core/__init__.py
@@ -4,7 +4,7 @@ This module initializes the Core package.
 
 from .error import (
     BaseError, InvalidSyntaxError, IllegalCharError, ExpectedCharError, RunTimeError, Position, IllegalOperationError,
-    AttributeError,TypeError
+    AttributeError,TypeError,ArgumentError
 )
 from .parser import (
     Parser, ParseResult, TernaryOperationNode, UnaryOperationNode, BinaryOperationNode, NumberNode
@@ -14,7 +14,7 @@ from .lexer import Lexer, Token
 
 __all__ = ["BaseError", "InvalidSyntaxError", "IllegalCharError",
            "ExpectedCharError", "RunTimeError", "Position", "IllegalOperationError",
-           "AttributeError","TypeError",
+           "AttributeError","ArgumentError","TypeError",
            "Parser", "ParseResult",
            "TernaryOperationNode", "UnaryOperationNode", "BinaryOperationNode", "NumberNode",
            "Lexer", "Token", "Interpreter", "Context", "RunTimeResult"]

--- a/sards/core/interpreter.py
+++ b/sards/core/interpreter.py
@@ -347,8 +347,8 @@ class Interpreter:
 
         func_name = node.var_name_tok.value if node.var_name_tok else None
         body_node = node.body_node
-        arg_names = [arg_name.value for arg_name in node.arg_name_toks]
-        func_value = (Function(func_name, body_node, arg_names, node.auto_return)
+        param_nodes = node.param_nodes
+        func_value = (Function(func_name, body_node, param_nodes, node.auto_return)
                       .set_context(context)
                       .set_pos(node.pos_start, node.pos_end))
 
@@ -359,7 +359,9 @@ class Interpreter:
 
     def visit_FunctionCallNode(self, node, context):
         res = RunTimeResult()
-        args = []
+        # UPDATED: Initialize separate lists for positional and keyword args
+        pos_args = []
+        kw_args = {}
 
         call_value = res.register(self.visit(node.call_node, context))
         if res.should_return():
@@ -367,18 +369,28 @@ class Interpreter:
         call_value = call_value.copy().set_pos(node.pos_start, node.pos_end)
 
         if not hasattr(call_value, 'execute'):
-            return res.failure(TypeError(
+            return res.failure(IllegalOperationError(
                 node.pos_start, node.pos_end,
                 f"'{type(call_value).__name__}' object is not callable",
                 context
             ))
 
-        for arg_node in node.arg_nodes:
-            args.append(res.register(self.visit(arg_node, context)))
+        # UPDATED: Process positional arguments
+        for arg_node in node.positional_arg_nodes:
+            pos_args.append(res.register(self.visit(arg_node, context)))
             if res.should_return():
                 return res
 
-        return_value = res.register(call_value.execute(args))
+        # UPDATED: Process keyword arguments
+        for name_tok, value_node in node.keyword_arg_nodes:
+            arg_name = name_tok.value
+            arg_value = res.register(self.visit(value_node, context))
+            if res.should_return():
+                return res
+            kw_args[arg_name] = arg_value
+
+        # UPDATED: Pass both positional and keyword args to execute
+        return_value = res.register(call_value.execute(pos_args, kw_args))
         if res.should_return():
             return res
 

--- a/sards/core/parser.py
+++ b/sards/core/parser.py
@@ -496,7 +496,7 @@ class Parser: # pylint: disable=R0904
         """
         Grammar Rule:
 
-        KEYWORD:init LPAREN (IDENTIFIER (COMMA IDENTIFIER)*)? RPAREN LPAREN2 NEWLINE*
+        KEYWORD:init LPAREN (param-list)? RPAREN LPAREN2 NEWLINE*
         (initializer-list)? (multiline | jump-statements)* NEWLINE* RPAREN2
         """
         res = ParseResult()
@@ -518,22 +518,9 @@ class Parser: # pylint: disable=R0904
         res.register_advancement()
         self.advance()
 
-        param_name_toks = []
-        if self.current_tok.type == T_IDENTIFIER:
-            param_name_toks.append(self.current_tok)
-            res.register_advancement()
-            self.advance()
-            while self.current_tok.type == T_COMMA:
-                res.register_advancement()
-                self.advance()
-                if self.current_tok.type != T_IDENTIFIER:
-                    return res.failure(InvalidSyntaxError(
-                        self.current_tok.pos_start, self.current_tok.pos_end,
-                        "Expected identifier"
-                    ))
-                param_name_toks.append(self.current_tok)
-                res.register_advancement()
-                self.advance()
+        param_nodes = res.register(self.param_list())
+        if res.error:
+            return res
 
         if self.current_tok.type != T_RPAREN:
             return res.failure(InvalidSyntaxError(
@@ -599,14 +586,14 @@ class Parser: # pylint: disable=R0904
         self.advance()
 
         body_node = ListNode(body_nodes, body_pos_start, pos_end)
-        return res.success(InitNode(param_name_toks, body_node, pos_start, pos_end))
+        return res.success(InitNode(param_nodes, body_node, pos_start, pos_end))
 
     def method_definition(self):
         """
         Grammar Rule:
 
         (KEYWORD:open | KEYWORD:guarded | KEYWORD:secret)? KEYWORD:method IDENTIFIER?
-        LPAREN (IDENTIFIER (COMMA IDENTIFIER)*)? RPAREN
+        LPAREN (param-list)? RPAREN
         LPAREN2 (multiline |jump-statements)* RPAREN2
         """
         res = ParseResult()
@@ -637,21 +624,9 @@ class Parser: # pylint: disable=R0904
         res.register_advancement()
         self.advance()
 
-        param_name_toks = []
-        if self.current_tok.type == T_IDENTIFIER:
-            param_name_toks.append(self.current_tok)
-            res.register_advancement()
-            self.advance()
-            while self.current_tok.type == T_COMMA:
-                res.register_advancement()
-                self.advance()
-                if self.current_tok.type != T_IDENTIFIER:
-                    return res.failure(InvalidSyntaxError(
-                        self.current_tok.pos_start, self.current_tok.pos_end, "Expected identifier"
-                    ))
-                param_name_toks.append(self.current_tok)
-                res.register_advancement()
-                self.advance()
+        param_nodes = res.register(self.param_list())
+        if res.error:
+            return res
 
         if self.current_tok.type != T_RPAREN:
             return res.failure(InvalidSyntaxError(
@@ -697,7 +672,7 @@ class Parser: # pylint: disable=R0904
         res.register_advancement()
         self.advance()
 
-        return res.success(FunctionDefinitionNode(name_tok, param_name_toks, body_node, False,access_modifier_tok))
+        return res.success(FunctionDefinitionNode(name_tok, param_nodes, body_node, False, access_modifier_tok))
 
     def initializer_list(self):
         """
@@ -1113,17 +1088,67 @@ class Parser: # pylint: disable=R0904
 
         return res.success(FinallyNode(body_node))
 
+    def param_item(self):
+        """
+        Grammar Rule: IDENTIFIER (EQUAL expression)?
+        """
+        res = ParseResult()
+
+        if self.current_tok.type != T_IDENTIFIER:
+            return res.failure(InvalidSyntaxError(
+                self.current_tok.pos_start, self.current_tok.pos_end,
+                "Expected parameter name (identifier)"
+            ))
+
+        param_name_tok = self.current_tok
+        res.register_advancement()
+        self.advance()
+
+        default_value = None
+        if self.current_tok.type == T_EQ:
+            res.register_advancement()
+            self.advance()
+            default_value = res.register(self.expression())
+            if res.error: return res
+
+        return res.success((param_name_tok, default_value))
+
+    def param_list(self):
+        """
+        Grammar Rule: (param-item (COMMA param-item)*)?
+        """
+        res = ParseResult()
+        params = []
+
+        if self.current_tok.type == T_RPAREN:
+            # Handles empty parameter list
+            return res.success(params)
+
+        # Parse the first parameter
+        item = res.register(self.param_item())
+        if res.error: return res
+        params.append(item)
+
+        # Parse subsequent parameters
+        while self.current_tok.type == T_COMMA:
+            res.register_advancement()
+            self.advance()
+
+            item = res.register(self.param_item())
+            if res.error: return res
+            params.append(item)
+
+        return res.success(params)
+
     def function_definition(self):
         """
         Grammar Rule:
-
         function-definition:
-            KEYWORD:method IDENTIFIER? LPAREN (IDENTIFIER (COMMA IDENTIFIER)*)? RPAREN
+            KEYWORD:method IDENTIFIER? LPAREN (param-list)? RPAREN
             LPAREN2 (multiline | jump-statements)* RPAREN2
         """
         res = ParseResult()
 
-        # 'method'
         if not (self.current_tok.type == T_KEYWORD and self.current_tok.value == 'method'):
             return res.failure(
                 InvalidSyntaxError(self.current_tok.pos_start,
@@ -1132,63 +1157,34 @@ class Parser: # pylint: disable=R0904
         res.register_advancement()
         self.advance()
 
-        # optional identifier (function name)
+        var_name_tok = None
         if self.current_tok.type == T_IDENTIFIER:
             var_name_tok = self.current_tok
             res.register_advancement()
             self.advance()
-            if self.current_tok.type != T_LPAREN:
-                return res.failure(
-                    InvalidSyntaxError(self.current_tok.pos_start,
-                                       self.current_tok.pos_end,
-                                       "Expected '('"))
-        else:
-            var_name_tok = None
-            if self.current_tok.type != T_LPAREN:
-                return res.failure(
-                    InvalidSyntaxError(self.current_tok.pos_start,
-                                       self.current_tok.pos_end,
-                                       "Expected '('"))
+
+        if self.current_tok.type != T_LPAREN:
+            return res.failure(
+                InvalidSyntaxError(self.current_tok.pos_start,
+                                   self.current_tok.pos_end,
+                                   "Expected '('"))
 
         res.register_advancement()
         self.advance()
 
-        # arguments
-        arg_name_toks = []
-        if self.current_tok.type == T_IDENTIFIER:
-            arg_name_toks.append(self.current_tok)
-            res.register_advancement()
-            self.advance()
+        arg_nodes = res.register(self.param_list())
+        if res.error:
+            return res
 
-            while self.current_tok and self.current_tok.type == T_COMMA:
-                res.register_advancement()
-                self.advance()
-
-                if self.current_tok.type != T_IDENTIFIER:
-                    return res.failure(
-                        InvalidSyntaxError(self.current_tok.pos_start,
-                                           self.current_tok.pos_end,
-                                           "Expected identifier"))
-
-                arg_name_toks.append(self.current_tok)
-                res.register_advancement()
-                self.advance()
-
-            if self.current_tok.type != T_RPAREN:
-                return res.failure(
-                    InvalidSyntaxError(self.current_tok.pos_start,
-                                       self.current_tok.pos_end,
-                                       "Expected ',' or ')'"))
-        else:
-            if self.current_tok.type != T_RPAREN:
-                return res.failure(
-                    InvalidSyntaxError(self.current_tok.pos_start, self.current_tok.pos_end,
-                                       "Expected identifier or ')'"))
+        if self.current_tok.type != T_RPAREN:
+            return res.failure(
+                InvalidSyntaxError(self.current_tok.pos_start,
+                                   self.current_tok.pos_end,
+                                   "Expected ',' or ')'"))
 
         res.register_advancement()
         self.advance()
 
-        # '{'
         if self.current_tok.type != T_LPAREN2:
             return res.failure(InvalidSyntaxError(self.current_tok.pos_start,
                                                   self.current_tok.pos_end,
@@ -1196,16 +1192,14 @@ class Parser: # pylint: disable=R0904
         res.register_advancement()
         self.advance()
 
-        # body
         body_nodes, pos_start = [], self.current_tok.pos_start
         while self.current_tok.type != T_RPAREN2 and self.current_tok.type != T_EOF:
-            if self.current_tok.type == T_KEYWORD and (self.current_tok.value in ("yield","proceed","escape")):
+            if self.current_tok.type == T_KEYWORD and (self.current_tok.value in ("yield", "proceed", "escape")):
                 jump_node = res.register(self.jump_statements())
                 if res.error: return res
                 body_nodes.append(jump_node)
             else:
                 multiline_node = res.try_register(self.multiline())
-
                 if res.error: return res
                 if not multiline_node:
                     if not (self.current_tok.type == T_KEYWORD and (
@@ -1220,7 +1214,6 @@ class Parser: # pylint: disable=R0904
 
         body_node = ListNode(body_nodes, pos_start, self.current_tok.pos_end)
 
-        # '}'
         if self.current_tok.type != T_RPAREN2:
             return res.failure(
                 InvalidSyntaxError(self.current_tok.pos_start,
@@ -1229,7 +1222,7 @@ class Parser: # pylint: disable=R0904
         res.register_advancement()
         self.advance()
 
-        return res.success(FunctionDefinitionNode(var_name_tok, arg_name_toks, body_node, False))
+        return res.success(FunctionDefinitionNode(var_name_tok, arg_nodes, body_node, False))
 
     def switch_statement(self):
         """
@@ -1908,11 +1901,110 @@ class Parser: # pylint: disable=R0904
                                    "Expected 'define',int,float,identifier,'+','-' or '('"))
         return res.success(node)
 
+    def keyword_item(self):
+        """
+        Grammar Rule: IDENTIFIER EQUAL expression
+        """
+        res = ParseResult()
+
+        if not (self.current_tok.type == T_IDENTIFIER and self.peek() and self.peek().type == T_EQ):
+            return res.failure(InvalidSyntaxError(
+                self.current_tok.pos_start, self.current_tok.pos_end,
+                "Expected keyword argument (identifier=value)"
+            ))
+
+        name_tok = self.current_tok
+        res.register_advancement()
+        self.advance()
+
+        res.register_advancement()
+        self.advance()
+
+        value_node = res.register(self.expression())
+        if res.error: return res
+
+        return res.success((name_tok, value_node))
+
+    def keyword_list(self):
+        """
+        Grammar Rule: keyword-item (COMMA keyword-item)*
+        """
+        res = ParseResult()
+        keywords = []
+
+        item = res.register(self.keyword_item())
+        if res.error: return res
+        keywords.append(item)
+
+        while self.current_tok.type == T_COMMA:
+            res.register_advancement()
+            self.advance()
+
+            item = res.register(self.keyword_item())
+            if res.error: return res
+            keywords.append(item)
+
+        return res.success(keywords)
+
+    def positional_list(self):
+        """
+        Grammar Rule: expression (COMMA expression)*
+        """
+        res = ParseResult()
+        positional_args = []
+
+        expr = res.register(self.expression())
+        if res.error: return res
+        positional_args.append(expr)
+
+        while self.current_tok.type == T_COMMA:
+            res.register_advancement()
+            self.advance()
+
+            if self.current_tok.type == T_IDENTIFIER and self.peek() and self.peek().type == T_EQ:
+                self.reverse()
+                break
+
+            expr = res.register(self.expression())
+            if res.error: return res
+            positional_args.append(expr)
+
+        return res.success(positional_args)
+
+    def argument_list(self):
+        """
+        Grammar Rule: positional-list (COMMA keyword-list)? | keyword-list
+        """
+        res = ParseResult()
+        positional_args = []
+        keyword_args = []
+
+        if self.current_tok.type == T_IDENTIFIER and self.peek() and self.peek().type == T_EQ:
+            keyword_args = res.register(self.keyword_list())
+            if res.error: return res
+
+        elif self.current_tok.type != T_RPAREN:
+            positional_args = res.register(self.positional_list())
+            if res.error: return res
+
+            if self.current_tok.type == T_COMMA:
+                res.register_advancement()
+                self.advance()
+
+                if not (self.current_tok.type == T_IDENTIFIER and self.peek() and self.peek().type == T_EQ):
+                    return res.failure(InvalidSyntaxError(
+                        self.current_tok.pos_start, self.current_tok.pos_end,
+                        "Positional argument cannot follow keyword argument"
+                    ))
+
+                keyword_args = res.register(self.keyword_list())
+                if res.error: return res
+
+        return res.success((positional_args, keyword_args))
+
     def call(self):
         """
-        Grammar Rule:
-
-        attr-access (LPAREN (expression(COMMA expression)*)? RPAREN)*
+        Grammar Rule: attr-access (LPAREN (argument-list)? RPAREN)*
         """
         res = ParseResult()
         atom = res.register(self.attr_access())
@@ -1922,32 +2014,23 @@ class Parser: # pylint: disable=R0904
         while self.current_tok.type == T_LPAREN:
             res.register_advancement()
             self.advance()
-            arg_nodes = []
+            positional_args, keyword_args = [], []
 
-            if self.current_tok.type == T_RPAREN:
-                res.register_advancement()
-                self.advance()
-            else:
-                arg_nodes.append(res.register(self.expression()))
+            if self.current_tok.type != T_RPAREN:
+                args = res.register(self.argument_list())
                 if res.error:
                     return res
+                positional_args, keyword_args = args
 
-                while self.current_tok.type == T_COMMA:
-                    res.register_advancement()
-                    self.advance()
-                    arg_nodes.append(res.register(self.expression()))
-                    if res.error:
-                        return res
+            if self.current_tok.type != T_RPAREN:
+                return res.failure(InvalidSyntaxError(
+                    self.current_tok.pos_start, self.current_tok.pos_end,
+                    "Expected ')'"
+                ))
+            res.register_advancement()
+            self.advance()
 
-                if self.current_tok.type != T_RPAREN:
-                    return res.failure(InvalidSyntaxError(
-                        self.current_tok.pos_start, self.current_tok.pos_end,
-                        "Expected ',' or ')'"
-                    ))
-                res.register_advancement()
-                self.advance()
-
-            atom = FunctionCallNode(atom, arg_nodes)
+            atom = FunctionCallNode(atom, positional_args, keyword_args)
 
         return res.success(atom)
 

--- a/sards/oops_types/class_instance.py
+++ b/sards/oops_types/class_instance.py
@@ -78,7 +78,7 @@ class ModelInstance:
             method = Function(
                 name,
                 method_node.body_node,
-                [tok.value for tok in method_node.arg_name_toks],
+                method_node.arg_nodes,
                 False,
                 self
             ).set_context(self.context)

--- a/sards/oops_types/class_type.py
+++ b/sards/oops_types/class_type.py
@@ -73,8 +73,8 @@ class Model:
         self.context = context
         return self
 
-    def execute(self, args):
-        from sards.core import Context, RunTimeResult, Interpreter
+    def execute(self, pos_args, kw_args):
+        from sards.core import Context, RunTimeResult, Interpreter, ArgumentError
 
         res = RunTimeResult()
         interpreter = Interpreter()
@@ -100,8 +100,10 @@ class Model:
 
         if self.init_node:
             init_func = Function(
-                "init", self.init_node.body_node,
-                [tok.value for tok in self.init_node.param_name_toks], False
+                "init",
+                self.init_node.body_node,
+                self.init_node.param_nodes,
+                False
             ).set_context(self.context)
             init_func.set_pos(self.init_node.pos_start, self.init_node.pos_end)
 
@@ -109,11 +111,23 @@ class Model:
             exec_context.symbol_table = instance.symbol_table
             exec_context.symbol_table.set("this", instance)
 
-            res.register(init_func.check_and_populate_args(init_func.arg_names, args, exec_context))
+            res.register(init_func.check_and_populate_args(
+                init_func.param_nodes,
+                pos_args,
+                kw_args,
+                exec_context
+            ))
             if res.should_return(): return res
 
             res.register(interpreter.visit(init_func.body_node, exec_context))
             if res.should_return(): return res
+
+        elif pos_args or kw_args:
+            return res.failure(ArgumentError(
+                self.pos_start, self.pos_end,
+                f"'{self.name}' does not have an 'init' method and takes no arguments for instantiation",
+                self.context
+            ))
 
         return res.success(instance)
 

--- a/sards/samples/main.sad
+++ b/sards/samples/main.sad
@@ -1,74 +1,20 @@
-model Creature {
-    secret attr<dna_id>
-    guarded attr<is_alive>
-
-    init(id) {
-        dna_id: id
-        is_alive: 1
+model Greeter {
+    attr<greeting>
+    init(greeting = "Hello") {
+        greeting:greeting
     }
 
-    guarded method metabolize() {
-        show("Creature is metabolizing.")
-    }
-
-    open method check_status() {
-        when is_alive {
-            show("It's alive!")
-        }
+    method greet(name, punctuation = "!") {
+        show(greeting+punctuation)
     }
 }
 
-model Mammal: Creature {
-    open attr<temperature>
-    secret attr<heart_rate>
+default_greeter = Greeter()
 
-    init(id, temp, rate) {
-        dna_id: id
-        is_alive: 1
-        temperature: temp
-        heart_rate: rate
-    }
+default_greeter.greet("World")
 
-    open method breathe() {
-        show("Mammal is breathing.")
-        metabolize()
-    }
+custom_greeter = Greeter(greeting = "Howdy")
 
-    open method check_status() {
-        show("Checking mammal status...")
-        when is_alive {
-            show("This mammal is alive.")
-        }
-    }
-}
+custom_greeter.greet("Sardine", punctuation = ".")
 
-model Lion: Mammal {
-    attr<pride_name>
-
-    init(id, temp, rate, pride) {
-        dna_id: id
-        is_alive: 1
-        temperature: temp
-        heart_rate: rate
-        pride_name: pride
-    }
-
-    secret method hunt() {
-        show("Lion is secretly hunting.")
-    }
-
-    open method roar() {
-        show("The lion from " + pride_name + " roars!")
-        hunt()
-    }
-}
-
-simba = Lion("L-42", 38, 80, "Pride Rock")
-simba.check_status()
-
-simba.breathe()
-
-simba.roar()
-
-show("Pride: " + simba.pride_name)
-show("Temp: " + String(simba.temperature))
+custom_greeter.greet(name = "Tester", punctuation = "!!")

--- a/sards/samples/main.sad
+++ b/sards/samples/main.sad
@@ -1,20 +1,28 @@
-model Greeter {
-    attr<greeting>
-    init(greeting = "Hello") {
-        greeting:greeting
+model ServerConfig {
+    attr<user, host, port, debug_mode>
+
+    init(user, host = "127.0.0.1", port = 8080, debug_mode = False) {
+        user: user
+        host: host
+        port: port
+        debug_mode: debug_mode
     }
 
-    method greet(name, punctuation = "!") {
-        show(greeting+punctuation)
+    method display_config(prefix = "Config:") {
+        show(prefix, "User=" + user, "Host=" + host, "Port=" + String(port), sep=" | ", end="\n\n")
     }
 }
 
-default_greeter = Greeter()
+show("--- Creating configurations ---", end="\n\n")
 
-default_greeter.greet("World")
+show("1. Default Config (using defaults for host, port, debug)")
+default_config = ServerConfig("admin")
+default_config.display_config()
 
-custom_greeter = Greeter(greeting = "Howdy")
+show("2. Custom Port (overriding 'port' positionally)")
+custom_port_config = ServerConfig("guest", "192.168.1.1", 9000)
+custom_port_config.display_config()
 
-custom_greeter.greet("Sardine", punctuation = ".")
-
-custom_greeter.greet(name = "Tester", punctuation = "!!")
+show("3. Debug Mode (overriding 'debug_mode' and 'user' by keyword)")
+debug_config = ServerConfig(user = "root", debug_mode = True)
+debug_config.display_config()

--- a/sards/shell.py
+++ b/sards/shell.py
@@ -35,7 +35,7 @@ global_symbol_table.set("show", BuiltInFunction.show)
 global_symbol_table.set("listen", BuiltInFunction.listen)
 global_symbol_table.set("Integer", BuiltInFunction.Integer)
 global_symbol_table.set("String", BuiltInFunction.String)
-global_symbol_table.set("type", BuiltInFunction.type)
+global_symbol_table.set("typeof", BuiltInFunction.typeof)
 
 
 def run(filename, input_text):

--- a/sards/user_functions/function_type.py
+++ b/sards/user_functions/function_type.py
@@ -11,7 +11,6 @@ from sards.ast_nodes import SymbolTable
 from sards.core.error import ArgumentError
 from sards.data_types import Number, String, List
 
-
 class BaseFunction:
     """
     A base class for functions in the abstract syntax tree (AST).
@@ -23,7 +22,7 @@ class BaseFunction:
         context: The context in which the function is executed.
     """
 
-    def __init__(self, name,instance=None):
+    def __init__(self, name, instance=None):
         """
         Initializes a BaseFunction instance.
 
@@ -31,7 +30,7 @@ class BaseFunction:
             name: The name of the function.
         """
         self.name = name or "<anonymous>"
-        self.instance=instance
+        self.instance = instance
         self.set_pos()
         self.set_context()
 
@@ -70,65 +69,69 @@ class BaseFunction:
         new_context.symbol_table = SymbolTable(new_context.parent.symbol_table)
         return new_context
 
-    def check_args(self, arg_names, args):
+    def check_and_populate_args(self, param_nodes, pos_args, kw_args, exec_context):
         """
-        Checks the arguments passed to the function.
+        Checks and populates arguments, now handling positional, keyword, and default arguments.
 
         Args:
-            arg_names: A list of argument names.
-            args: A list of arguments.
-
-        Returns:
-            res: The result of the argument check.
+            param_nodes: The list of (name_tok, default_value_node) tuples from the function definition.
+            pos_args: The list of positional arguments from the call.
+            kw_args: A dictionary of {name: value_node} for keyword arguments from the call.
+            exec_context: The context to populate with the final arguments.
         """
-        from sards.core import RunTimeResult
+        from sards.core import RunTimeResult, Interpreter
+
         res = RunTimeResult()
+        interpreter = Interpreter()
+        param_names = [p_name.value for p_name, _ in param_nodes]
+        final_args = {}
 
-        if len(args) > len(arg_names):
-            return res.failure(
-                ArgumentError(self.pos_start, self.pos_end,
-                    f"{len(args) - len(arg_names)} too many args passed into '{self.name}'",
-                    self.context))
+        if self.instance:
+            exec_context.symbol_table.set("this", self.instance)
 
-        if len(args) < len(arg_names):
-            return res.failure(
-                ArgumentError(self.pos_start, self.pos_end,
-                    f"{len(arg_names) - len(args)} too few args passed into '{self.name}'",
-                    self.context))
-        return res.success(None)
+        if len(pos_args) > len(param_names):
+            return res.failure(ArgumentError(
+                self.pos_start, self.pos_end,
+                f"{len(pos_args) - len(param_names)} too many arguments passed into '{self.name}'",
+                exec_context
+            ))
 
-    def populate_args(self, arg_names, args, context):
-        """
-        Populates the arguments in the function's context.
+        for i, arg_value in enumerate(pos_args):
+            final_args[param_names[i]] = arg_value
 
-        Args:
-            arg_names: A list of argument names.
-            args: A list of arguments.
-            context: The context to populate.
-        """
-        for i, arg_value in enumerate(args):
-            arg_name = arg_names[i]
-            arg_value.set_context(context)
-            context.symbol_table.set(arg_name, arg_value)
+        for name, value_node in kw_args.items():
+            if name not in param_names:
+                return res.failure(ArgumentError(
+                    self.pos_start, self.pos_end,
+                    f"Unexpected keyword argument '{name}' passed to '{self.name}'",
+                    exec_context
+                ))
+            if name in final_args:
+                return res.failure(ArgumentError(
+                    self.pos_start, self.pos_end,
+                    f"Multiple values for argument '{name}' passed to '{self.name}'",
+                    exec_context
+                ))
+            final_args[name] = value_node
 
-    def check_and_populate_args(self, arg_names, args, context):
-        """
-        Checks and populates the arguments in the function's context.
+        for p_name, p_default_value_node in param_nodes:
+            param_name = p_name.value
+            if param_name not in final_args:
+                if p_default_value_node:
+                    default_value = res.register(interpreter.visit(p_default_value_node, exec_context))
+                    if res.should_return(): return res
+                    final_args[param_name] = default_value
+                else:
+                    return res.failure(ArgumentError(
+                        self.pos_start, self.pos_end,
+                        f"Missing required argument '{param_name}' for function '{self.name}'",
+                        exec_context
+                    ))
 
-        Args:
-            arg_names: A list of argument names.
-            args: A list of arguments.
-            context: The context to populate.
+        for name, value in final_args.items():
+            value.set_context(exec_context)
+            exec_context.symbol_table.set(name, value)
 
-        Returns:
-            res: The result of the argument check and population.
-        """
-        from sards.core import RunTimeResult
-        res = RunTimeResult()
-        res.register(self.check_args(arg_names, args))
-        if res.should_return():
-            return res
-        self.populate_args(arg_names, args, context)
         return res.success(None)
 
 
@@ -138,27 +141,28 @@ class Function(BaseFunction):
 
     Attributes:
         body_node: The node representing the body of the function.
-        arg_names: A list of argument names.
+        param_nodes: A list of tuples: [(name_tok, default_value_node), ...].
         auto_return: A flag indicating whether the function automatically returns the last
         evaluated expression.
     """
-    def __init__(self, name, body_node, arg_names, auto_return,instance=None):
+
+    def __init__(self, name, body_node, param_nodes, auto_return, instance=None):
         """
         Initializes a Function instance.
 
         Args:
             name: The name of the function.
             body_node: The node representing the body of the function.
-            arg_names: A list of argument names.
+            param_nodes: A list of tuples: [(name_tok, default_value_node), ...].
             auto_return: A flag indicating whether the function automatically returns the last
             evaluated expression.
         """
-        super().__init__(name,instance)
+        super().__init__(name, instance)
         self.body_node = body_node
-        self.arg_names = arg_names
+        self.param_nodes = param_nodes
         self.auto_return = auto_return
 
-    def execute(self, args):
+    def execute(self, pos_args, kw_args):
         from sards.core import RunTimeResult, Interpreter, Context
 
         res = RunTimeResult()
@@ -167,15 +171,12 @@ class Function(BaseFunction):
         if self.instance:
             instance = self.instance
             method_owner = instance.model.find_method_owner(self.name)
-
             exec_context = Context(f"method {self.name}", instance.context, self.pos_start, owner_class=method_owner)
-
             exec_context.symbol_table = SymbolTable(instance.symbol_table)
-            exec_context.symbol_table.set("this", instance)
         else:
             exec_context = self.generate_new_context()
 
-        res.register(self.check_and_populate_args(self.arg_names, args, exec_context))
+        res.register(self.check_and_populate_args(self.param_nodes, pos_args, kw_args, exec_context))
         if res.should_return():
             return res
 
@@ -195,7 +196,7 @@ class Function(BaseFunction):
         Returns:
             copy: The copy of the function.
         """
-        copy = Function(self.name, self.body_node, self.arg_names, self.auto_return,self.instance)
+        copy = Function(self.name, self.body_node, self.param_nodes, self.auto_return, self.instance)
         copy.set_context(self.context)
         copy.set_pos(self.pos_start, self.pos_end)
         return copy
@@ -214,6 +215,7 @@ class BuiltInFunction(BaseFunction):
     """
     Represents a built-in function in the abstract syntax tree (AST).
     """
+
     def __init__(self, name):
         """
         Initializes a BuiltInFunction instance.
@@ -223,12 +225,13 @@ class BuiltInFunction(BaseFunction):
         """
         super().__init__(name)
 
-    def execute(self, args):
+    def execute(self, pos_args, kw_args):
         """
         Executes the built-in function with the given arguments.
 
         Args:
-            args: A list of arguments.
+            pos_args: A list of positional arguments.
+            kw_args: A dictionary of keyword arguments.
 
         Returns:
             res: The result of the function execution.
@@ -241,25 +244,14 @@ class BuiltInFunction(BaseFunction):
         method_name = f'execute_{self.name}'
         method = getattr(self, method_name, self.no_visit_method)
 
-        res.register(self.check_and_populate_args(method.arg_names, args, exec_context))
-        if res.should_return():
-            return res
-
-        return_value = res.register(method(exec_context))
+        return_value = res.register(method(pos_args, kw_args, exec_context))
         if res.should_return():
             return res
         return res.success(return_value)
 
-    def no_visit_method(self):
+    def no_visit_method(self, pos_args, kw_args, exec_context):
         """
         Raises an exception if the execute method is not defined.
-
-        Args:
-            node: The node to visit.
-            context: The context of the function.
-
-        Raises:
-            Exception: If the execute method is not defined.
         """
         raise NotImplementedError(f'No execute_{self.name} method defined')
 
@@ -284,103 +276,111 @@ class BuiltInFunction(BaseFunction):
         """
         return f"<built-in function {self.name}>"
 
-    def execute_show(self, exec_context):
+    def execute_show(self, pos_args, kw_args, exec_context):
         """
-        Executes the 'show' built-in function.
-
-        Args:
-            exec_context: The execution context.
-
-        Returns:
-            res: The result of the function execution.
+        Executes the 'show' built-in function with 'sep' and 'end' parameters.
         """
         from sards.core import RunTimeResult
-        print(str(exec_context.symbol_table.get('value')))
-        return RunTimeResult().success(Number(0))
 
-    execute_show.arg_names = ['value']
+        res = RunTimeResult()
+        separator = " "
+        end_char = "\n"
 
-    def execute_listen(self,exec_context):
+        for name, value in kw_args.items():
+            if name == 'sep':
+                if not isinstance(value, String):
+                    return res.failure(
+                        ArgumentError(self.pos_start, self.pos_end, "'sep' must be a string", self.context))
+                separator = value.value
+            elif name == 'end':
+                if not isinstance(value, String):
+                    return res.failure(
+                        ArgumentError(self.pos_start, self.pos_end, "'end' must be a string", self.context))
+                end_char = value.value
+            else:
+                return res.failure(
+                    ArgumentError(self.pos_start, self.pos_end, f"Unexpected keyword argument '{name}' for show",
+                                  self.context))
+
+        output = separator.join([str(arg.value) for arg in pos_args])
+        print(output, end=end_char)
+
+        return res.success(Number(0))
+
+    def execute_listen(self, pos_args, kw_args, exec_context):
         """
         Executes the 'listen' built-in function.
-
-        Args:
-            exec_context: The execution context.
-
-        Returns:
-            res: The result of the function execution.
         """
         from sards.core import RunTimeResult
+        res = RunTimeResult()
+        if len(pos_args) > 0 or len(kw_args) > 0:
+            return res.failure(ArgumentError(self.pos_start, self.pos_end, "listen() takes no arguments", self.context))
+
         text = input()
-        return RunTimeResult().success(String(text))
+        return res.success(String(text))
 
-    execute_listen.arg_names = []
-
-    def execute_Integer(self, exec_context): #pylint: disable=C0103
+    def execute_Integer(self, pos_args, kw_args, exec_context):  # pylint: disable=C0103
         """
         Executes the 'Integer' built-in function.
-
-        Args:
-            exec_context: The execution context.
-
-        Returns:
-            res: The result of the function execution.
         """
         from sards.core import RunTimeResult
+        res = RunTimeResult()
+        if len(pos_args) != 1 or len(kw_args) > 0:
+            return res.failure(
+                ArgumentError(self.pos_start, self.pos_end, "Integer() takes exactly one argument", self.context))
+
         try:
-            number = int(exec_context.symbol_table.get('value').value)
-        except ValueError as exc:
-            raise ValueError("Value Error: Cant convert to integer") from exc
+            number = int(pos_args[0].value)
+        except (ValueError, TypeError) as exc:
+            return res.failure(
+                ArgumentError(self.pos_start, self.pos_end, "Argument must be a value convertible to an integer",
+                              self.context))
 
-        return RunTimeResult().success(Number(number))
+        return res.success(Number(number))
 
-    execute_Integer.arg_names = ['value']
-
-    def execute_String(self, exec_context): #pylint: disable=C0103
+    def execute_String(self, pos_args, kw_args, exec_context):  # pylint: disable=C0103
         """
         Executes the 'String' built-in function.
-
-        Args:
-            exec_context: The execution context.
-
-        Returns:
-            res: The result of the function execution.
         """
         from sards.core import RunTimeResult
+        res = RunTimeResult()
+        if len(pos_args) != 1 or len(kw_args) > 0:
+            return res.failure(
+                ArgumentError(self.pos_start, self.pos_end, "String() takes exactly one argument", self.context))
+
         try:
-            string = str(exec_context.symbol_table.get('value').value)
-        except ValueError as exc:
-            raise ValueError("Value Error: Cant convert to string") from exc
+            string = str(pos_args[0].value)
+        except (ValueError, TypeError) as exc:
+            return res.failure(
+                ArgumentError(self.pos_start, self.pos_end, "Argument must be a value convertible to a string",
+                              self.context))
 
-        return RunTimeResult().success(String(string))
+        return res.success(String(string))
 
-    execute_String.arg_names = ['value']
-
-    def execute_type(self, exec_context):
+    def execute_type(self, pos_args, kw_args, exec_context):
         """
         Executes the 'type' built-in function.
-
-        Args:
-            exec_context: The execution context.
-
-        Returns:
-            res: The result of the function execution.
         """
         from sards.core import RunTimeResult
-        data = exec_context.symbol_table.get('value')
+        res = RunTimeResult()
+        if len(pos_args) != 1 or len(kw_args) > 0:
+            return res.failure(
+                ArgumentError(self.pos_start, self.pos_end, "type() takes exactly one argument", self.context))
+
+        data = pos_args[0]
         if isinstance(data, Number):
-            print("type <Number>")
+            print("<type Number>")
         elif isinstance(data, String):
-            print("type <String>")
+            print("<type String>")
         elif isinstance(data, List):
-            print("type <List>")
-        return RunTimeResult().success(Number(0))
+            print("<type List>")
+        else:
+            print(f"<type {type(data).__name__}>")
 
-    execute_type.arg_names = ['value']
-
+        return res.success(Number(0))
 
 BuiltInFunction.show = BuiltInFunction('show')
 BuiltInFunction.listen = BuiltInFunction('listen')
 BuiltInFunction.Integer = BuiltInFunction('Integer')
 BuiltInFunction.String = BuiltInFunction('String')
-BuiltInFunction.type = BuiltInFunction('type')
+BuiltInFunction.typeof = BuiltInFunction('typeof')


### PR DESCRIPTION
## Feat: Default Parameters & Keyword Arguments

This PR adds support for default parameter values in function definitions and keyword arguments in function calls, significantly improving flexibility and readability.

---
### Key Changes
* **Grammar:** Updated to parse `param = value` in definitions and `name = value` in calls.
* **AST:** `FunctionDefinitionNode` and `FunctionCallNode` were updated to store default values and distinguish between positional/keyword arguments.
* **Interpreter:** `check_and_populate_args` logic was rewritten to handle argument matching, default value evaluation, and arity checks.
* **OOP:** `Model.execute` was updated to correctly handle constructors (`init`) with the new argument types.

---
### Testing

The following code demonstrates all new functionality.

#### Test Code:
```sardine
model ServerConfig {
    attr<user, host, port>

    init(user, host = "127.0.0.1", port = 8080) {
        user: user
        host: host
        port: port
    }

    method display(prefix = "Config:") {
        show(prefix, user, host, String(port), sep=" | ")
    }
}

# 1. Using defaults for host and port
default_config = ServerConfig("admin")
default_config.display()

# 2. Overriding with keyword arguments
debug_config = ServerConfig(user = "root", port = 9090)
debug_config.display("[DEBUG]")
```

#### Output:
```
Config: | admin | 127.0.0.1 | 8080
[DEBUG] | root | 127.0.0.1 | 9090
```